### PR TITLE
bug: add exeption for NotImplementedError

### DIFF
--- a/leosTrack/track/adaptivetime.py
+++ b/leosTrack/track/adaptivetime.py
@@ -74,8 +74,10 @@ class AdaptiveTime(ComputeVisibility):
             # Check with jeremy what was the error that motivated this block
             try:
                 satellite_lon_lat_alt = satellite.get_lonlatalt(date_time)
-            except RuntimeError:
-                return None
+
+            except NotImplementedError:
+
+                continue
             ###################################################################
             # uses the observer coordinates to compute the satellite azimuth
             # and elevation, negative elevation implies satellite is under

--- a/leosTrack/track/fixtime.py
+++ b/leosTrack/track/fixtime.py
@@ -77,7 +77,7 @@ class FixWindow(ComputeVisibility):
 
                 satellite_lon_lat_alt = satellite.get_lonlatalt(date_time)
 
-            except RuntimeError:
+            except NotImplementedError:
 
                 continue
             ###################################################################
@@ -180,7 +180,7 @@ class FixWindow(ComputeVisibility):
         elif time_parameters["window"] == "evening":
             hour = 12
         else:
-            print(f"window must be: 'morning' or 'evening'")
+            print("window must be: 'morning' or 'evening'")
             sys.exit()
 
         start_date_time = datetime.datetime(

--- a/track.ini
+++ b/track.ini
@@ -7,13 +7,13 @@ window = evening
 
 [observation]
 observatory = lasilla
-satellite = all
+satellite = oneweb
 lowest_altitude_satellite = 30
 sun_zenith_lowest = 99
 sun_zenith_highest = 113
 
 [tle]
-download = False
+download = True
 # if download = False, load file below
 name = tle_bright.txt
 #name = tle_oneweb_2022-04-25_18:37:54.txt


### PR DESCRIPTION
For some data, there is the error message: NotImplementedError: Deep space calculations not supported. We add an exception in this case and skip the loop