### PR TITLE
bug: update regular expression to obtain satellites' list

### DIFF
--- a/leosTrack/tle.py
+++ b/leosTrack/tle.py
@@ -139,7 +139,9 @@ class TLE(FileDirectory):
         else:
 
             regular_expression = (
-                f"{satellite}.*[)]|{satellite}.*[0-9a-zA-Z]"
+                f"\n{satellite}.*[)][-]ID[-][0-9]*"
+                f"|"
+                f"\n{satellite}.*[0-9a-zA-Z][-]ID[-][0-9]*"
             )
 
         pattern = re.compile(regular_expression)

--- a/leosTrack/track/visible.py
+++ b/leosTrack/track/visible.py
@@ -215,7 +215,6 @@ class ComputeVisibility:
             dark_satellite: instance of class pyorbital.orbital.Orbital
 
         """
-
         dark_satellite = Orbital(satellite, tle_file=self.tle_file_location)
 
         return dark_satellite

--- a/track.ini
+++ b/track.ini
@@ -1,30 +1,29 @@
 [time]
 year = 2022
-month = 5
-day = 24
+month = 6
+day = 14
 delta = 60
 window = evening
 
 [observation]
-observatory = lasilla
-satellite = oneweb
+observatory = ckoir
+satellite = starlink
 lowest_altitude_satellite = 30
 sun_zenith_lowest = 99
-sun_zenith_highest = 113
+sun_zenith_highest = 112
 
 [tle]
 download = True
 # if download = False, load file below
-name = tle_bright.txt
-#name = tle_oneweb_2022-04-25_18:37:54.txt
+name = angular.txt
 
 [directory]
 work = /home/edgar/satellite-tracking
-output = ${work}/test/bright
+output = ${work}/eduardo_jp
 
 [file]
 simple = observing-details
 complete = visible
 
 [configuration]
-processes = 8
+processes = 12


### PR DESCRIPTION
The get_satellite_list method from TLE class outputs the list of satellites with unique IDs. The regular expression to get those satellites for a satellite brand had a bug. For instance it did't retrieve: STARLINK-1234 (VIROSAT)-ID-0001. Regular expression updated to be able to retrieve this satellites