### PR TITLE
bug: NotImplementedError in .get_observer_look

### DIFF
--- a/leosTrack/track/fixtime.py
+++ b/leosTrack/track/fixtime.py
@@ -61,12 +61,18 @@ class FixWindow(ComputeVisibility):
             observation_window_seconds / self.time_delta.total_seconds()
         )
         #######################################################################
-        previous_satellite_coordinates = satellite.get_observer_look(
-            date_time-self.time_delta,
-            self.observatory_data["longitude"],
-            self.observatory_data["latitude"],
-            self.observatory_data["altitude"] / 1000.0,
-        )
+        try:
+
+            previous_satellite_coordinates = satellite.get_observer_look(
+                date_time-self.time_delta,
+                self.observatory_data["longitude"],
+                self.observatory_data["latitude"],
+                self.observatory_data["altitude"] / 1000.0,
+            )
+
+        except NotImplementedError:
+
+            return satellite_name
         #######################################################################
         visible_satellite_data = []
         #######################################################################

--- a/track.ini
+++ b/track.ini
@@ -1,25 +1,25 @@
 [time]
 year = 2022
-month = 6
-day = 14
+month = 9
+day = 10
 delta = 60
-window = evening
+window = morning
 
 [observation]
-observatory = ckoir
-satellite = oneweb
+observatory = lasilla
+satellite = starlink
 lowest_altitude_satellite = 30
 sun_zenith_lowest = 99
 sun_zenith_highest = 112
 
 [tle]
-download = False
+download = True
 # if download = False, load file below
 name = angular.txt
 
 [directory]
 work = /home/edgar/satellite-tracking
-output = ${work}/test/angular
+output = ${work}/test/issue
 
 [file]
 simple = observing-details


### PR DESCRIPTION
Add try except to handle error: 
NotImplementedError('Mode "Near-space, simplified equations"') when using the get_observer_look method of the darksat objec from pyorbital