### PR TITLE
bug: fix raise Exception('Satellite crashed at time %s', utc_time)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ data/*
 *.npy
 # test output
 output/*
-test/*
+tests/*
 # Project specific ignores
 *.csv
 *.txt

--- a/leosTrack/track/fixtime.py
+++ b/leosTrack/track/fixtime.py
@@ -67,7 +67,7 @@ class FixWindow(ComputeVisibility):
         number_of_time_steps = int(
             observation_window_seconds / self.time_delta.total_seconds()
         )
-        #######################################################################
+        #################################################################
         try:
 
             previous_satellite_coordinates = satellite.get_observer_look(
@@ -80,9 +80,17 @@ class FixWindow(ComputeVisibility):
         except NotImplementedError:
 
             return satellite_name
-        #######################################################################
+
+        except Exception:
+            # catches either:
+            # 'Satellite crashed at time %s', utc_time
+            # 'e**2 >= 1 at %s', utc_time
+
+            return satellite_name
+
+        #################################################################
         visible_satellite_data = []
-        #######################################################################
+        #################################################################
         print(f"Compute visibility of: {satellite_name}", end="\r")
 
         for _ in range(number_of_time_steps):
@@ -97,7 +105,7 @@ class FixWindow(ComputeVisibility):
             except NotImplementedError:
 
                 continue
-            ###################################################################
+            #############################################################
             # uses the observer coordinates to compute the satellite azimuth
             # and elevation, negative elevation implies satellite is under
             # the horizon. altitude must be in kilometers
@@ -109,7 +117,7 @@ class FixWindow(ComputeVisibility):
                 self.observatory_data["latitude"],
                 self.observatory_data["altitude"] / 1000.0,
             )
-            ###################################################################
+            #############################################################
             # gets the Sun's RA and DEC at the time of observation
             # sun_right_ascension, sun_declination = sun_coordinates
 
@@ -121,7 +129,7 @@ class FixWindow(ComputeVisibility):
                 right_ascension=sun_coordinates[0]
             )
             sun_coordinates[1] = np.rad2deg(sun_coordinates[1])
-            ###################################################################
+            #############################################################
             self._update_observer_date(date_time)
 
             [
@@ -130,7 +138,7 @@ class FixWindow(ComputeVisibility):
             ] = self.get_satellite_ra_dec_from_azimuth_and_altitude(
                 satellite_coordinates[0], satellite_coordinates[1]
             )
-            ###################################################################
+            #############################################################
             sun_zenith = pyorbital.astronomy.sun_zenith_angle(
                 date_time,
                 self.observatory_data["longitude"],
@@ -143,7 +151,7 @@ class FixWindow(ComputeVisibility):
 
             if satellite_visibility is True:
                 print(f"{satellite_name} is visible", end="\r")
-                ###############################################################
+                #########################################################
                 # compute the change in AZ and ALT of the satellite position
                 # between current and previous observation
                 angular_velocity = self.angular_velocity(
@@ -161,14 +169,14 @@ class FixWindow(ComputeVisibility):
                     sun_zenith,
                     angular_velocity,
                 )
-                ##############################################################
+                #########################################################
                 visible_satellite_data.append([data_str, data_str_simple])
-            ###################################################################
+            #############################################################
             # current position, time as the "previous" for next observation
             # use [:] to make a copy of list
             previous_satellite_coordinates = satellite_coordinates[:]
             date_time += self.time_delta
-        #######################################################################
+        #################################################################
         if len(visible_satellite_data) > 0:
             return [[satellite_name] + data for data in visible_satellite_data]
 

--- a/leosTrack/track/fixtime.py
+++ b/leosTrack/track/fixtime.py
@@ -105,6 +105,13 @@ class FixWindow(ComputeVisibility):
             except NotImplementedError:
 
                 continue
+
+            except Exception:
+                # catches either:
+                # 'Satellite crashed at time %s', utc_time
+                # 'e**2 >= 1 at %s', utc_time
+
+                continue
             #############################################################
             # uses the observer coordinates to compute the satellite azimuth
             # and elevation, negative elevation implies satellite is under

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,4 @@
-certifi==2021.10.8
-charset-normalizer==2.0.12
-ephem==4.1.3
-idna==3.3
-numpy==1.22.3
-pandas==1.4.2
-pyorbital==1.7.1
-python-dateutil==2.8.2
-pytz==2022.1
-requests==2.27.1
-scipy==1.8.0
-six==1.16.0
-urllib3==1.26.9
+numpy==1.21.5
+pandas==1.3.5
+pyephem==9.99
+pyorbital==1.7.3

--- a/track.ini
+++ b/track.ini
@@ -1,7 +1,7 @@
 [time]
 year = 2022
 month = 9
-day = 10
+day = 12
 delta = 60
 window = morning
 
@@ -10,16 +10,16 @@ observatory = lasilla
 satellite = starlink
 lowest_altitude_satellite = 30
 sun_zenith_lowest = 100
-sun_zenith_highest = 112
+sun_zenith_highest = 111
 
 [tle]
 download = False
 # if download = False, load file below
-name = tle_Starlink_2022-09-10_08_15_22.txt
+name = tle_starlink_2022-10-11_13_12_01.txt
 
 [directory]
 work = /home/edgar/satellite-tracking
-output = ${work}/test/issue/angular
+output = ${work}/tests/crash
 
 [file]
 simple = observing-details

--- a/track.ini
+++ b/track.ini
@@ -1,7 +1,7 @@
 [time]
-year = 2022
-month = 9
-day = 12
+year = 2023
+month = 2
+day = 10
 delta = 60
 window = morning
 
@@ -13,13 +13,13 @@ sun_zenith_lowest = 100
 sun_zenith_highest = 111
 
 [tle]
-download = False
+download = True
 # if download = False, load file below
-name = tle_starlink_2022-10-11_13_12_01.txt
+name = tle_Starlink_2022-09-10_08_15_22.txt
 
 [directory]
 work = /home/edgar/satellite-tracking
-output = ${work}/tests/crash
+output = ${work}/error/
 
 [file]
 simple = observing-details


### PR DESCRIPTION
Fix bug to avoid this satellite with except Exception:
+                # catches either:
+                # 'Satellite crashed at time %s', utc_time
+                # 'e**2 >= 1 at %s', utc_time. At this point we must be careful on properly treat those exceptions. Either we contribute to pyorbiatal or add a wapper to our module